### PR TITLE
Fix eventmanager typedef

### DIFF
--- a/types/EventManager.d.ts
+++ b/types/EventManager.d.ts
@@ -8,7 +8,7 @@ export declare class EventManager {
      * @param {string} name
      * @return {Set}
      */
-    get(name: string): Set;
+    get(name: string): Set<Function>;
 
     /**
      * @param {string}   eventName

--- a/types/EventManager.d.ts
+++ b/types/EventManager.d.ts
@@ -1,3 +1,5 @@
+import EventEmitter from 'events';
+
 export declare class EventManager {
     constructor();
 
@@ -19,7 +21,7 @@ export declare class EventManager {
      * @param {EventEmitter} emitter
      * @param {Object} config
      */
-    attach(emitter: EventEmitter, config: Object);
+    attach(emitter: typeof EventEmitter, config?: Object);
 
     /**
      * Remove all listeners for a given emitter or only those for the given events
@@ -32,5 +34,5 @@ export declare class EventManager {
      * @param {EventEmitter}  emitter
      * @param {?string|iterable} events Optional name or list of event names to remove listeners from
      */
-    detach(emitter: EventEmitter, events: ?string|iterable): void;
+    detach(emitter: typeof EventEmitter, events?: string | string[]): void;
 }


### PR DESCRIPTION
This types EventEmitter properly as well as the Set returned from one method. Also fixes some syntax issues that may have come up from copying JSDocs.