### PR TITLE
Fix damage types

### DIFF
--- a/types/Damage.d.ts
+++ b/types/Damage.d.ts
@@ -15,7 +15,7 @@ export declare class Damage {
      * @param {*} [source=null] Where the damage came from: skill, item, room, etc.
      * @property {Object} metadata Extra info about the damage: type, hidden, critical, etc.
      */
-    constructor(attribute: string, amount: number, attacker: Character, source: any, metadata: object);
+    constructor(attribute: string, amount: number, attacker?: Character, source?: any, metadata?: object);
 
     /**
      * Evaluate actual damage taking attacker/target's effects into account

--- a/types/Damage.d.ts
+++ b/types/Damage.d.ts
@@ -1,6 +1,14 @@
+import { Attribute } from "./Attribute";
+
 import { Character } from "./Character";
 
 export declare class Damage {
+    attribute: Attribute;
+    amount: number;
+    attacker?: Character;
+    source?: any;
+    metadata?: object;
+
     /**
      * @param {string} attribute Attribute the damage is going to apply to
      * @param {number} amount

--- a/types/Damage.d.ts
+++ b/types/Damage.d.ts
@@ -1,5 +1,4 @@
 import { Attribute } from "./Attribute";
-
 import { Character } from "./Character";
 
 export declare class Damage {


### PR DESCRIPTION
The Damage class constructor had some parameters set to required when they are actually optional, and did not define its own member properties (which are used commonly in bundle code).